### PR TITLE
par30games.net

### DIFF
--- a/PersianBlocker.txt
+++ b/PersianBlocker.txt
@@ -1561,6 +1561,7 @@ par30games.net##[href^="https://playpod.ir/"]
 par30games.net##.fixedadv:upward(3)
 par30games.net##.fixedbanner
 par30games.net##.sidebar-box-shop
+par30games.net##.ads
 !#if env_mobile
 par30games.net##.mobilebanner
 !#endif

--- a/PersianBlocker.txt
+++ b/PersianBlocker.txt
@@ -1557,6 +1557,7 @@ parsipet.ir##.body_wrapper > div:nth-of-type(4)
 ! https://github.com/AdguardTeam/AdguardFilters/issues/83232
 ! https://github.com/MasterKia/PersianBlocker/issues/4
 ! https://github.com/MasterKia/PersianBlocker/issues/9
+! https://github.com/MasterKia/PersianBlocker/pull/19
 par30games.net##[href^="https://playpod.ir/"]
 par30games.net##.fixedadv:upward(3)
 par30games.net##.fixedbanner


### PR DESCRIPTION
این فیلتر برای بخش بالای دیدگاه کاربران هست.
درسته که دوتا خودتبلیغی رو هم پنهان میکنه ولی با توجه به توضیحات خود سایت، اگه سفارش جدیدی بگیرن قاعدتا به جای اون‌ها یه تبلیغ جدید میاد: https://par30games.net/adv (جایگاه E1)

در مورد بقیه‌ی خود‌تبلیغی‌های این سایت و سایت‌های دیگه که ممکنه در آینده بجاشون تبلیغ نمایش داده بشه، زمانی که تبلیغ نمایش بدن فیلترشون رو اضافه میکنید؟
یا اگه الان هم به لیست اضافه بشن مشکلی نداره؟