### PR TITLE
GitHub Linguist support for adblock rules

### DIFF
--- a/PersianBlocker.txt
+++ b/PersianBlocker.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: PersianBlocker
 ! Description: سرانجام، یک لیست بهینه و گسترده برای مسدودسازی تبلیغ ها و ردیاب ها در سایت های پارسی زبان!
 ! Expires: 4 days

--- a/PersianBlockerHosts.txt
+++ b/PersianBlockerHosts.txt
@@ -1,3 +1,4 @@
+[AdBlock]
 # ------------------------------------[UPDATE]--------------------------------------
 # Title: PersianBlocker (Hosts)
 # Expires: 2 day


### PR DESCRIPTION
GitHub now supports syntax highlighting of adblock filter lists, but this requires the presence of the adblock agent