### PR TITLE
Fix CSS injection

### DIFF
--- a/PersianBlocker.txt
+++ b/PersianBlocker.txt
@@ -1796,7 +1796,7 @@ khabareazad.com##.sticky_notify
 @@||dl.konkur.in/image/ads/gold.png$image,1p
 konkur.in###HeaderImg
 konkur.in##[id^="tabligh"]
-konkur.in##.sidebar-taliq:style(visibility: hidden; !important;)
+konkur.in##.sidebar-taliq:style(visibility: hidden !important;)
 konkur.in##.text-center:has-text(پست تبلیغاتی):upward(3)
 konkur.in##.tabliqat-text
 konkur.in##.m-top10:has-text(تبلیغات)


### PR DESCRIPTION
One uBO CSS injection had an unnecessary semicolon before the important keyword, this PR removes it