### PR TITLE
Blocks paid promotional links on zoomit.ir and removes the divider line after them

### DIFF
--- a/PersianBlocker.txt
+++ b/PersianBlocker.txt
@@ -3846,6 +3846,9 @@ zoomit.ir##+js(href-sanitizer, a[variant="contained"][href^="https://api2.zoomit
 zoomit.ir##div#price div.bg-card:has(> div[role="button"] > div.relative div[variant="subhead"][font-weight="bold"][lineheight="1.6"]):style(opacity: 0.5 !important; filter: blur(0.4px) !important; transition: border .3s ease, opacity .3s ease !important;)
 zoomit.ir##div#price div.bg-card:has(> div[role="button"] > div.relative div[variant="subhead"][font-weight="bold"][lineheight="1.6"]):hover:style(opacity: 1 !important; filter: blur(0) !important;)
 zoomit.ir##div#price div.bg-card:has(> div[role="button"] > div.relative div[variant="subhead"][font-weight="bold"][lineheight="1.6"]):active:style(opacity: 1 !important; filter: blur(0) !important;)
+! Zoomit.ir - Remove paid links & divider
+www.zoomit.ir##:xpath(//a[starts-with(@href, "https://www.zoomit.ir/pr/")])
+www.zoomit.ir##:xpath(//a[starts-with(@href, "https://www.zoomit.ir/pr/")]/following-sibling::div[contains(@class, "bg-borderPrimary")][1])
 
 !-------------------------^ Site-Specific Filters ^-----------------------!
 


### PR DESCRIPTION

Zoomit adds these <a> links to some of their articles to promote or advertise products. All of these links start with https://www.zoomit.ir/pr/ — so it's clear they are affiliate or paid promotional links.

Used an XPath filter to block them because:

- These links are dynamically generated (sometimes JavaScript adds them after page load), so regular ##a[href^=...] filters didn't work.

- XPath is powerful enough to detect them based on their href pattern.

- It's very specific → It only targets those promo links and the divider line that comes right after them → without affecting normal content.

![zoomit-paid-links-block](https://github.com/user-attachments/assets/ac96b681-a41a-48a7-9c13-8bd6b84a1d0f)
