### PR TITLE
soft98.ir

### DIFF
--- a/PersianBlockerCensor.txt
+++ b/PersianBlockerCensor.txt
@@ -72,7 +72,6 @@ www.bing.com##a[href][href*="&mediaurl="][target="_blank"][title][href^="/images
 duckduckgo.com##a[href][data-testid="result-title-a"]:where([href*="soft98.ir/"])::after:style(content: ' ⚠️ ضد کاربر | Anti-User ⚠️ ' !important; color: red !important; font-weight: bold !important;)
 search.brave.com##a[href][class$="heading-serpresult"]:where([href*="soft98.ir/"])::after:style(content: ' ⚠️ ضد کاربر | Anti-User ⚠️ ' !important; color: red !important; font-weight: bold !important;)
 zarebin.ir##a[href][class^="!text-link"]:where([href*="soft98.ir/"])::after:style(content: ' ⚠️ ضد کاربر | Anti-User ⚠️ ' !important; color: red !important; font-weight: bold !important;)
-||soft98.ir^$script
 soft98.ir,~forum.soft98.ir##img[src^="https://img.soft98.ir/"]:upward(1):style(clip-path: circle(0) !important;)
 soft98.ir,~forum.soft98.ir##html:style(position: static !important; transform: none !important; filter: none !important; -webkit-filter: none !important; backdrop-filter: none !important; opacity: 1 !important; visibility: visible !important; mix-blend-mode: normal !important; clip-path: none !important;)
 soft98.ir,~forum.soft98.ir##body:style(filter: none !important; -webkit-filter: none !important; backdrop-filter: none !important; opacity: 1 !important; visibility: visible !important; mix-blend-mode: normal !important; clip-path: none !important;)


### PR DESCRIPTION
as listed in Free Media Heck Yeah (FMHY) PersianBlocker might cause an breakage for soft98
https://github.com/fmhy/edit/blob/main/docs/.vitepress/notes/soft98-note.md

i did test this in my personal setup it does indeed there is a one line causing this issue blocking the script does cause this issue with AdGuard Extra and AdGuard Ads unblocking the script doesn't seem to break persianblocker's warning in my setup as you could see it would show:
<img width="2323" height="1440" alt="image" src="https://github.com/user-attachments/assets/a51b9c76-90d3-4abd-926a-b4399a8240c9" />
