### PR TITLE
Improve PersianBlocker README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,270 +1,144 @@
-<h3 align="center">
+# PersianBlocker
 
-![Sayyed Ali “Master” Kia](static/masterkia.jpg)
-> 🕯️ Sayyed Ali “Master” Kia, the original author and maintainer of PersianBlocker, has recently passed away. May he receive the peace he was denied in this life. 🖤
+<p align="center">
+  <strong>یک فهرست فیلتر فارسی برای مسدودسازی تبلیغ‌ها، ردیاب‌ها، مزاحمت‌ها و تهدیدهای رایج در وب فارسی</strong>
+</p>
 
-</h3>
+<p align="center">
+  <a href="https://github.com/MasterKia/PersianBlocker/blob/main/LICENSE">
+    <img alt="License: AGPL v3" src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg">
+  </a>
+  <a href="https://www.jsdelivr.com/package/gh/MasterKia/PersianBlocker">
+    <img alt="jsDelivr" src="https://data.jsdelivr.com/v1/package/gh/MasterKia/PersianBlocker/badge">
+  </a>
+  <a href="https://github.com/MasterKia/PersianBlocker/stargazers">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/MasterKia/PersianBlocker?style=social">
+  </a>
+</p>
 
-<h1 align="center">
-     
-[![FSF - Free Software Foundation](https://img.shields.io/badge/FSF-Free_Software_Foundation-brightgreen)](https://www.fsf.org/)          [![Donate to FSF](https://img.shields.io/badge/Donate%20to%20FSF-%234E9A06?style=flat)](https://www.fsf.org/donate) 
+> Sayyed Ali "Master" Kia، نویسنده و نگهدارنده اصلی PersianBlocker، درگذشته است. این پروژه یاد و کار او را زنده نگه می‌دارد: بازگرداندن اختیار به کاربر برای اینکه چه چیزی وارد مرورگرش بشود و چه چیزی نشود.
 
-[![GNU - GNU Project](https://img.shields.io/badge/GNU-GNU/Linux_Operating_System-red)](https://www.gnu.org/)          [![Donate to GNU](https://img.shields.io/badge/Donate%20to%20GNU-%23FF4500?style=flat)](https://www.gnu.org/donate)
+## معرفی
 
-[![Support Stallman](https://img.shields.io/badge/Support-Stallman-yellow?style=flat-square)](https://stallmansupport.org)
+PersianBlocker مجموعه‌ای از فیلترهای سازگار با uBlock Origin، AdGuard و ابزارهای مشابه است که برای وب‌سایت‌های فارسی‌زبان و سرویس‌های پرکاربرد کاربران ایرانی، افغانستانی و تاجیکستانی نگهداری می‌شود.
 
-     
-[![Please don't upload to GitHub](https://nogithub.codeberg.page/badge.svg)](https://nogithub.codeberg.page)
+این پروژه برای مسدودسازی این موارد طراحی شده است:
 
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+- تبلیغات نمایشی، پاپ‌آپ‌ها و شبکه‌های تبلیغاتی
+- ردیاب‌ها و سامانه‌های تحلیل رفتار کاربر
+- مزاحمت‌های بصری و عناصر آزاردهنده صفحه
+- دامنه‌های بدافزار، فیشینگ و پیامک‌های ناخواسته
+- فهرست‌های hosts و domains برای ابزارهای خارج از مرورگر
 
-![GitHub Repo stars](https://img.shields.io/github/stars/MasterKia/PersianBlocker?style=social&logo=github&label=Stars)          
+## نصب سریع
 
-[![jsDelivr Stats](https://data.jsdelivr.com/v1/package/gh/MasterKia/PersianBlocker/badge)](https://www.jsdelivr.com/package/gh/MasterKia/PersianBlocker?tab=stats)
+### uBlock Origin
 
+اگر از uBlock Origin استفاده می‌کنید، روی لینک زیر بزنید و سپس گزینه Subscribe را انتخاب کنید:
 
-[![Telegram Group](https://img.shields.io/endpoint?color=neon&style=flat-square&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2FPersianBlocker)](https://telegram.dog/PersianBlocker)         [![Matrix](https://img.shields.io/matrix/PersianBlocker%3Amatrix.org?server_fqdn=matrix.org&style=flat&logo=matrix)](https://matrix.to/#/#PersianBlocker:matrix.org)
+[افزودن PersianBlocker به uBlock Origin](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlocker.txt&title=PersianBlocker)
 
-GitHub Discussions: https://github.com/MasterKia/PersianBlocker/discussions/49
+اگر لینک بالا باز نشد:
 
-Telegram Group: [@PersianBlocker](https://telegram.dog/PersianBlocker)
+1. داشبورد uBlock Origin را باز کنید.
+2. به بخش `Filter lists` بروید.
+3. بخش `Regions` را باز کنید.
+4. گزینه `IRN: PersianBlocker` را فعال کنید.
+5. روی `Update now` بزنید.
 
-Matrix Room: https://matrix.to/#/#PersianBlocker:matrix.org
+### AdGuard
 
+در AdGuard به مسیر زیر بروید:
 
-</h1>
+`Settings` -> `Filters` -> `Language-specific`
 
-***
-<h1 align="center">
-Android & iOS content blocking extensions and apps:
-     
-https://fmhy.net/android-iosguide#android-adblocking
+سپس فیلتر `Persian Blocker` را پیدا و فعال کنید.
 
-https://fmhy.net/android-iosguide#ios-adblocking
-</h1>
+### نصب دستی
 
-***
+اگر برنامه شما از نشانی خام فیلتر پشتیبانی می‌کند، این آدرس را وارد کنید:
 
-<h1 align="center">
-🆓 BreakFree
-</h1>
+```text
+https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlocker.txt
+```
 
-Related link:
+## کدام فایل را انتخاب کنم؟
 
-sing-box configurations for plug-n-play usage, using freely available sources.
+| فایل | کاربرد | لینک خام |
+| --- | --- | --- |
+| `PersianBlocker.txt` | فهرست اصلی برای uBlock Origin و AdGuard | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlocker.txt) |
+| `PersianBlockerAds.txt` | فقط تبلیغات | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerAds.txt) |
+| `PersianBlockerTrackers.txt` | فقط ردیاب‌ها | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerTrackers.txt) |
+| `PersianBlockerAnnoyances.txt` | عناصر مزاحم و آزاردهنده | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerAnnoyances.txt) |
+| `PersianBlockerMalware.txt` | دامنه‌ها و الگوهای مرتبط با بدافزار | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerMalware.txt) |
+| `PersianBlockerPhishing.txt` | دامنه‌ها و الگوهای فیشینگ | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerPhishing.txt) |
+| `PersianBlockerMobile.txt` | موارد مرتبط با وب و اپ‌های موبایل | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerMobile.txt) |
+| `PersianBlockerHosts.txt` | نسخه مناسب برای hosts-based blockers | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerHosts.txt) |
+| `PersianBlockerAds-Domains.txt` | دامنه‌های تبلیغاتی | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerAds-Domains.txt) |
+| `PersianBlockerTrackers-Domains.txt` | دامنه‌های ردیابی | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerTrackers-Domains.txt) |
+| `PersianBlockerCensor-Domains.txt` | دامنه‌های مرتبط با سانسور و اختلال | [raw](https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerCensor-Domains.txt) |
 
-📣 Our Telegram: https://BreakRealFree.t.me
-🎁 Donate: https://demarcush.github.io/#-donation
+برای بیشتر کاربران، همان `PersianBlocker.txt` کافی است.
 
-***
+## توصیه‌های استفاده
 
-<h1 align="center">
-<sub>
-<img src="https://github.com/gorhill/uBlock/blob/master/src/img/ublock.svg" height="38" width="38">
-</sub>
-uBlock Origin (uBO)
-</h1>
+- هم‌زمان چند افزونه مسدودساز تبلیغ را فعال نکنید؛ این کار می‌تواند باعث کندی، تداخل و خطای مسدودسازی شود.
+- اگر مرورگر شما مسدودساز داخلی دارد، هنگام استفاده از uBlock Origin یا AdGuard تنظیمات آن را بررسی کنید.
+- فهرست‌ها به‌صورت دوره‌ای به‌روزرسانی می‌شوند؛ در برنامه مسدودساز خود auto-update را روشن نگه دارید.
+- برای بهترین سازگاری با uBlock Origin، استفاده از Firefox پیشنهاد می‌شود.
 
-Related link: https://github.com/uBlockOrigin/uAssets/discussions/13259
+## گزارش مشکل
 
-uBlock Origin (uBO) is a CPU and memory-efficient wide-spectrum content blocker for Chromium and Firefox. It blocks ads, trackers, coin miners, popups, annoying anti-blockers, malware sites, etc., by default using EasyList, EasyPrivacy, Peter Lowe's Blocklist, Online Malicious URL Blocklist, and uBO filter lists. There are many other lists available to block even more. Hosts files are also supported. uBO uses the EasyList filter syntax and extends the syntax to work with custom rules and filters.
+اگر تبلیغی نمایش داده می‌شود، سایتی خراب شده، یا دامنه‌ای اشتباه مسدود شده است، لطفا یک issue باز کنید:
 
-| Browser   | Install from ... | Status |
-| :-------: | ---------------- | ------ |
-| <img src="https://github.com/user-attachments/assets/b0136512-56a5-4856-8c50-4971c957a24f" alt="Get uBlock Origin for Firefox"> | <a href="https://addons.mozilla.org/addon/ublock-origin/">Firefox Add-ons</a> | [uBO works best on Firefox](https://github.com/gorhill/uBlock/wiki/uBlock-Origin-works-best-on-Firefox) |
-| <img src="https://github.com/user-attachments/assets/3a7569f8-688b-4eb1-a643-8d0fe173aefe" alt="Get uBlock Origin for Microsoft Edge"> | <a href="https://microsoftedge.microsoft.com/addons/detail/ublock-origin/odfafepnkmbhccpbejgmiehpchacaeak">Edge Add-ons</a> |
-| <img src="https://github.com/user-attachments/assets/938f080c-fe64-4e48-8b89-4bfceabb56e6" alt="Get uBlock Origin for Opera"> | <a href="https://addons.opera.com/extensions/details/ublock/">Opera Add-ons</a> |
-| <img src="https://github.com/user-attachments/assets/5463ef88-873b-4516-8514-5277664cfde7" alt="Get uBlock Origin for Chromium"> | <a href="https://chromewebstore.google.com/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh">Chrome Web Store</a> | <a href="https://github.com/uBlockOrigin/uBlock-issues/wiki/About-Google-Chrome's-%22This-extension-may-soon-no-longer-be-supported%22">About Google Chrome's "This extension may soon no longer be supported"</a><br>End of support on Chrome 139 |
-| <img src="https://github.com/user-attachments/assets/2e9037c4-836d-44c1-a716-ba96e89daaff" alt="Get uBlock Origin for Thunderbird"> | <a href="https://addons.thunderbird.net/en-Us/thunderbird/addon/ublock-origin/">Thunderbird Add-ons</a> | [No longer updated and stuck at 1.49.2](https://github.com/uBlockOrigin/uBlock-issues/issues/2928) |
+[گزارش مشکل در GitHub Issues](https://github.com/MasterKia/PersianBlocker/issues)
 
-***
+برای گزارش دقیق‌تر، این موارد را بنویسید:
 
-<h1 align="center">
-<a name="AdGuard"></a> AdGuard
-</h1>
+- نشانی صفحه‌ای که مشکل دارد
+- نام مرورگر و افزونه مسدودساز
+- فهرست‌هایی که فعال کرده‌اید
+- توضیح کوتاه از رفتار مورد انتظار و رفتار فعلی
+- در صورت امکان، تصویر یا نمونه فیلتر پیشنهادی
 
-Related link: https://github.com/AdguardTeam/FiltersRegistry/issues/617
+## مشارکت
 
-AdGuard is a fast and lightweight ad blocking browser extension that effectively blocks all types of ads and trackers on all web pages. We focus on advanced privacy protection features to not just block known trackers, but prevent web sites from building your shadow profile. Unlike its standalone counterparts (AG for Windows, Mac), the browser extension is completely free and open source. You can learn more about [the difference](https://adguard.com/compare.html) here.
+مشارکت‌ها از راه pull request پذیرفته می‌شوند:
 
-### <a name="installation-chrome"></a> Chrome and Chromium-based browsers
+[ارسال Pull Request](https://github.com/MasterKia/PersianBlocker/pulls)
 
-You can get the latest available AdGuard Extension version from the
-[Chrome Web Store](https://agrd.io/extension_chrome).
+پیش از ارسال تغییر:
 
-### <a name="installation-firefox"></a> Firefox
+1. مطمئن شوید فیلتر تا حد ممکن محدود و دقیق است.
+2. از مسدودسازی گسترده دامنه‌ها بدون دلیل روشن خودداری کنید.
+3. اگر فیلتر برای یک سایت خاص است، نام سایت یا زمینه آن را در کنار فیلتر مشخص کنید.
+4. در صورت امکان، فیلتر را با uBlock Origin یا AdGuard آزمایش کنید.
 
-You can get the latest version of AdGuard Extension from the
-[Mozilla Add-ons website](https://agrd.io/extension_firefox).
+## توسعه محلی
 
-### <a name="installation-opera"></a> Opera
+این پروژه با `pnpm` و ابزارهای lint مخصوص فیلترهای AdGuard/uBlock نگهداری می‌شود.
 
-Opera is basically a Chromium browser, but it maintains its own add-ons store.
-You can get AdGuard Extension [from there](https://agrd.io/extension_opera).
+```bash
+pnpm install
+pnpm lint
+pnpm build
+```
 
-### <a name="installation-edge"></a> Microsoft Edge
+اسکریپت‌های اصلی:
 
-The latest stable version of AdGuard browser extension is available in
-[Microsoft Store](https://agrd.io/extension_edge).
+| دستور | توضیح |
+| --- | --- |
+| `pnpm lint` | اجرای بررسی‌های فیلترها و Markdown |
+| `pnpm lint:ab` | بررسی فیلترها با `aglint` |
+| `pnpm lint:md` | بررسی فایل‌های Markdown |
+| `pnpm build` | ساخت خروجی‌ها با اسکریپت پروژه |
 
-***
+## جامعه
 
-<h1 align="center">
-<a name="AdGuard"></a> AdGuard for Windows
-</h1>
+- Telegram: [@PersianBlocker](https://telegram.dog/PersianBlocker)
+- Matrix: [#PersianBlocker:matrix.org](https://matrix.to/#/#PersianBlocker:matrix.org)
+- Discussions: [GitHub Discussions](https://github.com/MasterKia/PersianBlocker/discussions/49)
 
-AdGuard for Windows will not only block all types of ads in any browser and application,
-but also offers the highest level of online privacy protection.
+## مجوز
 
-To get more information and to download AdGuard for Windows, visit our website https://adguard.com/.
-
-***
-
-<h1 align="center">
-<a name="AdGuard"></a> AdGuard for Android
-</h1>
-
-AdGuard for Android is a unique tool that blocks ads in apps and browsers even without ROOT privileges, protects your privacy, and helps you manage your apps. AdGuard gives you options of running it either VPN or HTTP proxy mode and allows to set up custom DNS settings (with DNSCrypt support).
-
-To get more information and to download AdGuard for Android, visit our website https://adguard.com/.
-
-***
-
-<h1 align="center">
-<a name="AdGuard"></a> AdGuard for iOS
-</h1>
-
-AdGuard for iOS is an app that blocks ads in Safari browser at exceptional level, and also provides additional Premium features like configurable DNS settings, encrypted DNS support (DOH, DOT, DNSCrypt), and custom ad blocking subscriptions. To get more information and to download AdGuard for iOS, visit our website.
-
-***
-
-<h1 align="center">
-<a name="AdGuard"></a> AdGuard for Safari
-</h1>
-
-Ad blocking extensions for Safari are having hard time since Apple [started to force everyone](https://adguard.com/en/blog/safari-adblock-extensions/) to use the new SDK. AdGuard extension is supposed to bring back the high quality ad blocking back to Safari.
-
-Unlike other major ad blockers, AdGuard provides some extra features you are used to have with the traditional (now deprecated) extensions:
-
-* Managing protection from Safari
-* Choose among popular filter subscription
-* Custom filters
-* Creating your own filtering rules
-* Manual blocking tool
-* Allowlisting websites
-
-AdGuard for Safari is based on the Safari native content blocking API, which makes it lightning fast, but somewhat limited in capabilities. For instance, Safari limits the number of rules a content blocker can have.
-
-***
-
-<h1 align="center">
-<a name="AdGuard"></a> AdGuard for Mac
-</h1>
-
-With all above said, there is a solution that is even more effective than AG Safari extension. I mean, of course, [AdGuard for Mac](https://adguard.com/adguard-mac/overview.html). It can:
-
-* filter your traffic in all browsers and apps on your Mac
-* have an unlimited number of filter rules
-* provide a better filtering quality (due to the lack of browser API restrictions)
-
-You can [try it out for free](https://adguard.com/en/download.html?os=mac&show=1).
-
-***
-
-<h1 align="center">
-<a name="AdGuard"></a> Rethink DNS + Firewall + VPN for Android
-</h1>
-
-Related link: https://github.com/celzero/rethink-app/issues/569
-
-A [WireGuard](https://github.com/wireguard/wireguard-go) client, an [OpenSnitch](https://github.com/evilsocket/opensnitch)-inspired firewall and network monitor + a [pi-hole](https://github.com/pi-hole/pi-hole)-inspired DNS over HTTPS client with blocklists.
-
-[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
-     alt="Get it on F-Droid"
-     height="70">](https://f-droid.org/packages/com.celzero.bravedns/)
-[<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png"
-     alt="Get it on Google Play"
-     height="70">](https://play.google.com/store/apps/details?id=com.celzero.bravedns)
-
-<sup>*Release certificate SHA-256 digest*: `1f32d432e81a1dc5c00aafeb0c6636cd7819965d174420e59db9675dff7a88e9`.</sup>
-
-In other words, Rethink DNS + Firewall has three primary modes, VPN, DNS, and Firewall. The VPN (proxifier) mode supports multiple WireGuard upstreams in a split-tunnel configuration. The DNS mode routes all DNS traffic generated by apps to _any_ user chosen DNS-over-HTTPS or DNSCrypt resolver. The Firewall mode lets the user deny internet-access to entire applications based on events like screen-on / screen-off, app-foreground / app-background, unmetered-connection / metered-connection; or based on play-store defined categories like Social, Games, Utility, Productivity; or additionally, based on user-defined denylists.
-
-![2](https://github.com/celzero/rethink-app/assets/56958445/618bb47c-586c-41b9-ba1c-f62c2bbc9649)
-![3](https://github.com/celzero/rethink-app/assets/56958445/c74f3485-7197-4e5b-860f-c2b11c556cee)
-![4](https://github.com/celzero/rethink-app/assets/56958445/a2032d44-f07c-45e9-801b-7abe0cac0ead)
-![5](https://github.com/celzero/rethink-app/assets/56958445/b9973e69-d45e-4be9-bd42-b80fb2768ec5)
-
-
-***
-
-<h1 align="center">
-V2RayAggregator
-</h1>
-
-Related link: https://github.com/mahdibland/V2RayAggregator?tab=readme-ov-file#credit
-
-The automation functions of this repository are all implemented based on `GitHub Actions`
-
-Test the speed of each free node pool on the network and the nodes shared by bloggers to screen out relatively stable and high-speed nodes, and then import them into the warehouse for sharing records.
-
-The speed measurement function is implemented in the `GitHub Actions` environment using [LiteSpeedTest](https://github.com/xxf098/LiteSpeedTest), so there are many nodes in the United States, which cannot well represent the node availability in the domestic network environment.
-
-## Features
-- Lots of sources 😯
-- Remove all duplicate nodes 🤤
-- Providing nodes in major formats (YAML, clash, v2ray, base64) 🦋
-- No additional conversion to prevent breaking the nodes 🌿
-- Filtering best nodes by testing them and sorting them based on their average speed 🍀
-
-***
-
-<h1 align="center">
-Chocolate4U
-</h1>
-
-Related link: https://github.com/Chocolate4U/Iran-v2ray-rules/blob/release/ads.txt
-
-This is an Enhanced and All-in-One set of geo-location routing files optimized for Iranian users to use in v2ray/xray/Clash/Clash.Meta/sing-box and all their compatible clients.
-
-:bulb: For Sing-Box geolocation rules please refer to [Iran Sing-Box Rules](https://github.com/Chocolate4U/Iran-sing-box-rules)
-
-:bulb: For Clash geolocation rules please refer to [Iran Clash Rules](https://github.com/Chocolate4U/Iran-clash-rules)
-
-:bulb: For Clash geolocation rules please refer to [Iran V2Ray Rules](https://github.com/Chocolate4U/Iran-v2ray-rules)
-
-***
-<h1 align="center">
-EnergizedProtection
-</h1>
-
-Related link: https://github.com/EnergizedProtection/block/issues/1042
-
-The Energized Protection system is a powerful and flexible solution designed to shield your devices from ads, trackers, and malware—no matter what operating system you use. By combining protection packs from trusted sources, it ensures a secure browsing experience across all platforms, including Windows, macOS, Linux, and mobile devices. Whether you're on a phone, laptop, or desktop, Energized Protection provides seamless, reliable security to keep your digital experience smooth and secure.
-
-***
-<h1 align="center">
-FilterLists.com
-</h1>
-
-Related link: https://filterlists.com/lists/persianblocker-official-regional-persianiranian-domains-and-cosmetic-blocklist
-
-***
-<h1 align="center">
-V2RayGen/XRayGen
-</h1>
-
-Related link: https://github.com/SonyaCore/V2RayGen?tab=readme-ov-file#block-list-sources
-
-A Fast and Automated Script for XRay/V2Ray Server Setup.
-
-***
-<h1 align="center">
-Brave Browser
-</h1>
-
-Related link: https://github.com/brave/adblock-resources/blob/50d0a69fbfbe6e2f0a50b6e1535a32b6e853688a/filter_lists/list_catalog.json#L682-L698
-***
-
-
-[![Star History Chart](https://api.star-history.com/svg?repos=MasterKia/PersianBlocker&type=date&legend=top-left)](https://www.star-history.com/#MasterKia/PersianBlocker&type=date&legend=top-left)
+PersianBlocker تحت مجوز [GNU AGPLv3](https://github.com/MasterKia/PersianBlocker/blob/main/LICENSE) منتشر شده است.


### PR DESCRIPTION
# Improve PersianBlocker README

## Summary

- Replaces the current link-heavy README with a clearer Persian project overview.
- Adds quick setup instructions for uBlock Origin, AdGuard, and manual filter subscriptions.
- Adds a table explaining the main filter files and their raw subscription links.
- Documents reporting, contribution, and local development workflows.
- Keeps a respectful note for Sayyed Ali "Master" Kia, the original author and maintainer.

## Why

The existing README is difficult to scan and mixes project documentation with many external references. This update makes the repository landing page more useful for new users, contributors, and maintainers by putting installation, file selection, and support information first.

## Validation

- Checked the existing README and repository files through GitHub.
- Verified the replacement README renders as standard Markdown and keeps the existing project links, license, community links, and primary filter URLs.
